### PR TITLE
fix(encoding) suppot UTF-8 characters in request

### DIFF
--- a/asp-core/build.gradle
+++ b/asp-core/build.gradle
@@ -1,3 +1,4 @@
 dependencies {
+     compile group: 'org.apache.commons', name: 'commons-text', version: '1.8'
      compile project(':asp-api')
 }

--- a/asp-core/build.gradle
+++ b/asp-core/build.gradle
@@ -1,4 +1,3 @@
 dependencies {
-     compile group: 'org.apache.commons', name: 'commons-text', version: '1.8'
      compile project(':asp-api')
 }

--- a/asp-core/src/main/java/de/jcup/asp/core/CryptoAccess.java
+++ b/asp-core/src/main/java/de/jcup/asp/core/CryptoAccess.java
@@ -15,6 +15,9 @@
  */
 package de.jcup.asp.core;
 
+import static org.apache.commons.text.StringEscapeUtils.escapeJava;
+import static org.apache.commons.text.StringEscapeUtils.unescapeJava;
+
 import java.security.SecureRandom;
 import java.util.Base64;
 
@@ -72,7 +75,7 @@ public class CryptoAccess {
         try {
             Cipher cipher = Cipher.getInstance(SECURITY_ALGORITHM);
             cipher.init(Cipher.ENCRYPT_MODE, secretKey, new SecureRandom());
-            byte[] encryptedBytes = cipher.doFinal(strToEncrypt.getBytes("UTF-8"));
+            byte[] encryptedBytes = cipher.doFinal(escapeJava(strToEncrypt).getBytes("ISO-8859-1"));
             return Base64.getEncoder().encodeToString(encryptedBytes);
             
         } catch (Exception e) {
@@ -86,7 +89,7 @@ public class CryptoAccess {
             cipher.init(Cipher.DECRYPT_MODE, secretKey);
             byte[] base64ToDecrypt = Base64.getDecoder().decode(strToDecrypt);
             byte[] decryptedBytes = cipher.doFinal(base64ToDecrypt);
-            return new String(decryptedBytes);
+            return unescapeJava(new String(decryptedBytes));
         } catch (Exception e) {
             if (e instanceof BadPaddingException) {
                 /* bad key detected */

--- a/asp-core/src/main/java/de/jcup/asp/core/CryptoAccess.java
+++ b/asp-core/src/main/java/de/jcup/asp/core/CryptoAccess.java
@@ -15,9 +15,6 @@
  */
 package de.jcup.asp.core;
 
-import static org.apache.commons.text.StringEscapeUtils.escapeJava;
-import static org.apache.commons.text.StringEscapeUtils.unescapeJava;
-
 import java.security.SecureRandom;
 import java.util.Base64;
 
@@ -75,7 +72,7 @@ public class CryptoAccess {
         try {
             Cipher cipher = Cipher.getInstance(SECURITY_ALGORITHM);
             cipher.init(Cipher.ENCRYPT_MODE, secretKey, new SecureRandom());
-            byte[] encryptedBytes = cipher.doFinal(escapeJava(strToEncrypt).getBytes("ISO-8859-1"));
+            byte[] encryptedBytes = cipher.doFinal(strToEncrypt.getBytes("UTF-8"));
             return Base64.getEncoder().encodeToString(encryptedBytes);
             
         } catch (Exception e) {
@@ -89,7 +86,7 @@ public class CryptoAccess {
             cipher.init(Cipher.DECRYPT_MODE, secretKey);
             byte[] base64ToDecrypt = Base64.getDecoder().decode(strToDecrypt);
             byte[] decryptedBytes = cipher.doFinal(base64ToDecrypt);
-            return unescapeJava(new String(decryptedBytes));
+            return new String(decryptedBytes, "UTF-8");
         } catch (Exception e) {
             if (e instanceof BadPaddingException) {
                 /* bad key detected */

--- a/asp-core/src/test/java/de/jcup/asp/core/CryptoAccessTest.java
+++ b/asp-core/src/test/java/de/jcup/asp/core/CryptoAccessTest.java
@@ -88,5 +88,18 @@ public class CryptoAccessTest {
 
     }
     
+    @Test
+    public void decrypted_string_support_UTF8_characters() throws Exception {
+        /* prepare */
+        CryptoAccess cryptoAccess = new CryptoAccess();
+        String value = cryptoAccess.decrypt(cryptoAccess.encrypt("héllo world"));
+        
+        
+        /* test */
+        assertNotNull(value);
+        assertEquals("héllo world",value);
+
+    }
+    
 
 }

--- a/asp-core/src/test/java/de/jcup/asp/core/CryptoAccessTest.java
+++ b/asp-core/src/test/java/de/jcup/asp/core/CryptoAccessTest.java
@@ -92,12 +92,12 @@ public class CryptoAccessTest {
     public void decrypted_string_support_UTF8_characters() throws Exception {
         /* prepare */
         CryptoAccess cryptoAccess = new CryptoAccess();
-        String value = cryptoAccess.decrypt(cryptoAccess.encrypt("héllo world"));
+        String value = cryptoAccess.decrypt(cryptoAccess.encrypt("h\u00E9llo world"));
         
         
         /* test */
         assertNotNull(value);
-        assertEquals("héllo world",value);
+        assertEquals("h\u00E9llo world",value);
 
     }
     

--- a/asp-server-core/src/main/java/de/jcup/asp/server/core/CoreAspServer.java
+++ b/asp-server-core/src/main/java/de/jcup/asp/server/core/CoreAspServer.java
@@ -98,7 +98,7 @@ public class CoreAspServer {
         LOG.debug("Server waiting for client call");
         try (Socket clientSocket = serverSocket.accept();
                 PrintWriter out = new PrintWriter(clientSocket.getOutputStream(), true);
-                BufferedReader in = new BufferedReader(new InputStreamReader(clientSocket.getInputStream()))) {
+                BufferedReader in = new BufferedReader(new InputStreamReader(clientSocket.getInputStream(), "UTF-8"))) {
 
             StringBuilder sb = new StringBuilder();
             String encryptedFromClient = null;


### PR DESCRIPTION
* Escape non ISO-8859-1 characters using Apache commons-test
`StringEscapeUtil.escapeJava` before using the Base64 encoder (only
supports ISO-8859-1) at encryption.
* Unescape UTF-8 characters when decrypting using the dual method
`StringEscapeUtil.unescapeJava`

Closes https://github.com/de-jcup/asp/issues/23